### PR TITLE
Adds uncertain / save for later category

### DIFF
--- a/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
+++ b/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
@@ -87,7 +87,7 @@ app.layout = html.Div([
                 options = [
                     {'label': 'True (alarm is correct)', 'value': 'True'},
                     {'label': 'False (alarm is incorrect)', 'value': 'False'},
-                    {'label': 'Uncertain', 'value': 'Uncertain'}
+                    {'label': 'Uncertain / Save for later', 'value': 'Uncertain'}
                 ],
                 labelStyle = {'display': 'block'},
                 style = {'width': sidebar_width,},
@@ -145,19 +145,20 @@ app.layout = html.Div([
 
 def get_user_events(user, project_folder):
     """
-    Get the events assigned to a user in the CSV file
+    Get the events assigned to a user in the CSV file.
 
     Parameters
     ----------
     user : User
-        The User whose events will be retrieved
+        The User whose events will be retrieved.
     project_folder : str
-        The project used to retrieve the events
+        The project used to retrieve the events.
 
     Returns
     -------
-    list
-        List of events assigned to the user
+    N/A: list
+        List of events assigned to the user.
+
     """
     # Find the files
     BASE_DIR = base.BASE_DIR
@@ -177,6 +178,7 @@ def get_user_events(user, project_folder):
                     names.append(val)
             if user.username in names:
                 event_list.append(row[0])
+
     user_ann = Annotation.objects.filter(user=user, project=project_folder)
     event_list += [a.event for a in user_ann if a not in event_list]
 
@@ -185,19 +187,20 @@ def get_user_events(user, project_folder):
 
 def get_user_records(user):
     """
-    Get the records assigned to a user in the CSV file
+    Get the records assigned to a user in the CSV file.
 
     Parameters
     ----------
     user : User
-        The User whose records will be retrieved
+        The User whose records will be retrieved.
     project_folder : str
-        The project used to retrieve the records
+        The project used to retrieve the records.
 
     Returns
     -------
-    dict
-        Dict of records assigned to the user by project
+    N/A: dict
+        The records assigned to the user by project.
+
     """
     annotations = Annotation.objects.filter(user=user)
 
@@ -218,6 +221,7 @@ def get_user_records(user):
     for ann in annotations:
         if ann.record not in user_records[ann.project]:
             user_records[ann.project].append(ann.record)
+
     return user_records
 
 

--- a/waveform-django/waveforms/templates/waveforms/annotations.html
+++ b/waveform-django/waveforms/templates/waveforms/annotations.html
@@ -60,24 +60,24 @@
   </div><br /><br />
   <div>
     {% if finished_assignment %}
-    <form action="" method="post">
-      {% csrf_token %}
-      <h2>Annotate More Events</h2>
-      <label for="num_events">Number of events to assign:</label>
-      <input id="num_events" type="number" name="num_events" value="100" min="100" max="800" required
-             value="Must assign at least 100 events">
-      <br>
-      <input type="submit" name="new_assignment" class="btn btn-primary btn-rsp" value="Submit">
-    </form>
+      <form action="" method="post">
+        {% csrf_token %}
+        <h2>Annotate More Events</h2>
+        <label for="num_events">Number of events to assign:</label>
+        <input id="num_events" type="number" name="num_events" value="100" min="100" max="800" required
+              value="Must assign at least 100 events">
+        <br>
+        <input type="submit" name="new_assignment" class="btn btn-primary btn-rsp" value="Submit">
+      </form>
     {% else %}
       <h2>Current Assignment</h2>
       <span style="font-size: 20px; float: left;">Remaining Events: </span>
-      <span style="font-size: 20px; float: right;">{{remaining}}</span>
+      <span style="font-size: 20px; float: right;">{{ remaining }}</span>
     {% endif %}
     <br><br>
   </div>
-  <div><h2>Incomplete Annotations</h2></div>
-  {% for rec,info in incompleted_anns.items %}
+  <div><h2>Uncertain / Saved Annotations</h2></div>
+  {% for rec,info in uncertain_anns.items %}
     <button class="accordion">
       <span style="float: left;">{{ info.1 }}:&emsp;{{ rec }}</span>
       <span style="float: right;">{{ info.0 }}</span>
@@ -106,7 +106,7 @@
             <!-- Only display if annotation (timestamp) is found -->
             {% if val.3 != "-" %}
               <td>
-                <a href="{% url 'delete_annotation' rec val.0 %}">Delete annotation</a>
+                <a href="{% url 'delete_annotation' info.1 rec val.0 %}">Delete annotation</a>
               </td>
             {% endif %}
           </tr>
@@ -133,6 +133,45 @@
         </tr>
         <!-- Values of each column -->
         {% for val in info|slice:"2:" %}
+          <tr>
+            {% for v in val %}
+              <td>
+                {{ v }}
+              </td>
+            {% endfor %}
+            <td>
+              <a href="{% url 'waveform_published_specific' info.1 rec val.0 %}">Edit annotation</a>
+            </td>
+            <!-- Only display if annotation (timestamp) is found -->
+            {% if val.3 != "-" %}
+              <td>
+                <a href="{% url 'delete_annotation' info.1 rec val.0 %}">Delete annotation</a>
+              </td>
+            {% endif %}
+          </tr>
+        {% endfor %}
+      </table>
+    </div>
+  {% endfor %}
+  <br />
+  <div><h2>Incomplete Annotations</h2></div>
+  {% for rec,info in incompleted_anns.items %}
+    <button class="accordion">
+      <span style="float: left;">{{ rec }}</span>
+      <span style="float: right;">{{ info.0 }}</span>
+    </button>
+    <div class="panel">
+      <table style="width:100%">
+        <!-- Header names of the columns -->
+        <tr>
+          {% for cat in categories %}
+            <th>
+              {{ cat }}
+            </th>
+          {% endfor %}
+        </tr>
+        <!-- Values of each column -->
+        {% for val in info|slice:"1:" %}
           <tr>
             {% for v in val %}
               <td>


### PR DESCRIPTION
This change adds a new category for the annotator to review their annotations in which they may see any events they were unsure about. To qualify, the annotation must have been marked as "Uncertain". To help the user understand this new functionality, I adjusted the "Uncertain" radio button option to say "Uncertain / Save for later" to let the annotator know they may go back any time they wish via the links from the "Completed Annotations" list. I also adjusted the ordering of that page to now display "Uncertain / Save for later" annotations, then "Complete" annotations, and finally "Incomplete" annotations.