### PR TITLE
Allow admins to adjust admin control

### DIFF
--- a/waveform-django/waveforms/templates/waveforms/admin_console.html
+++ b/waveform-django/waveforms/templates/waveforms/admin_console.html
@@ -126,8 +126,9 @@
         <th>Username</th>
         <th>Join Date</th>
         <th>Last Login</th>
-        <th>Annotations Created</th>
-        <th>New Settings &lt;{field: [default,user set], ...}&gt;</th>
+        <th style="width:15%">Total Number of Annotations (across all projects)</th>
+        <th style="width:25%">New Settings &lt;{field: [default,user set], ...}&gt;</th>
+        <th>Admin Control</th>
       </tr>
       {% for u in all_users %}
         <tr>
@@ -136,6 +137,23 @@
           <td>{{ u.last_login }}</td>
           <td>{{ u.num_annotations }}</td>
           <td>{{ u.new_settings }}</td>
+          <td>
+            {% if u.is_admin %}
+              <div class="btn-container-rsp mg-left">
+                <form action="{% url 'admin_console' %}" method="post" class="form-signin row no-pd" name="remove_admin">
+                  {% csrf_token %}
+                  <button class="btn btn-danger btn-rsp" name="remove_admin" value="{{ u.username }}" type="submit">Remove Admin</button>
+                </form>
+              </div>
+            {% else %}
+              <div class="btn-container-rsp mg-left">
+                <form action="{% url 'admin_console' %}" method="post" class="form-signin row no-pd" name="add_admin">
+                  {% csrf_token %}
+                  <button class="btn btn-primary btn-rsp" name="add_admin" value="{{ u.username }}" type="submit">Add Admin</button>
+                </form>
+              </div>
+            {% endif %}
+          </td>
         </tr>
       {% endfor %}
     </table>

--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from operator import itemgetter
 import csv
 
+from django import forms
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
@@ -199,6 +200,8 @@ def admin_console(request):
         return redirect('waveform_published_home')
 
     invite_user_form = InviteUserForm()
+    add_admin_form = forms.Form()
+    remove_admin_form = forms.Form()
 
     if request.method == 'POST':
         if 'invite_user' in request.POST:
@@ -226,6 +229,18 @@ def admin_console(request):
                             names.remove(user.username)
                 update_assignments(csv_data, project)
             return redirect('admin_console')
+        elif 'add_admin' in request.POST:
+            new_admin = User.objects.get(
+                username__exact=request.POST['add_admin']
+            )
+            new_admin.is_admin = True
+            new_admin.save()
+        elif 'remove_admin' in request.POST:
+            new_admin = User.objects.get(
+                username__exact=request.POST['remove_admin']
+            )
+            new_admin.is_admin = False
+            new_admin.save()
 
     # Find the files
     BASE_DIR = base.BASE_DIR
@@ -315,7 +330,9 @@ def admin_console(request):
                    'conflict_anns': conflict_anns,
                    'unanimous_anns': unanimous_anns, 'all_anns': all_anns,
                    'all_users': all_users,
-                   'invite_user_form': invite_user_form})
+                   'invite_user_form': invite_user_form,
+                   'add_admin_form': add_admin_form,
+                   'remove_admin_form': remove_admin_form})
 
 
 @login_required


### PR DESCRIPTION
This change allows admins to adjust who are the other admins. To implement this, I added a button to the right side of the information listed for each user which states "Add admin" for users who are not already admins and "Remove admin" for user who already admins. Users can also adjust their own admin status so be careful! (remove buttons are in red to help reinforce... maybe I should have a "confirm" dialog also)

In the future, it would be nice to keep track of who is an admin on a per-project basis but I don't see us needing this for at least some time.