### PR TITLE
Fixes annotation page numbers

### DIFF
--- a/waveform-django/waveforms/templates/waveforms/annotations.html
+++ b/waveform-django/waveforms/templates/waveforms/annotations.html
@@ -157,7 +157,7 @@
   <div><h2>Incomplete Annotations</h2></div>
   {% for rec,info in incompleted_anns.items %}
     <button class="accordion">
-      <span style="float: left;">{{ rec }}</span>
+      <span style="float: left;">{{ info.1 }}:&emsp;{{ rec }}</span>
       <span style="float: right;">{{ info.0 }}</span>
     </button>
     <div class="panel">
@@ -171,7 +171,7 @@
           {% endfor %}
         </tr>
         <!-- Values of each column -->
-        {% for val in info|slice:"1:" %}
+        {% for val in info|slice:"2:" %}
           <tr>
             {% for v in val %}
               <td>

--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -399,7 +399,7 @@ def render_annotations(request):
             user_records[ann.project].append(ann.record)
 
     # Get the total number of annotations
-    total_anns = len(all_annotations)
+    total_anns = sum([len(user_events[k]) for k in user_events.keys()])
 
     # Display user events
     for project,record_list in user_records.items():
@@ -439,8 +439,8 @@ def render_annotations(request):
                 uncertain_anns[rec] = temp_uncertain_anns
             if temp_incompleted_anns != []:
                 total_incompleted_anns = total_anns - \
-                                        len(completed_annotations) - \
-                                        len(uncertain_annotations)
+                                         len(completed_annotations) - \
+                                         len(uncertain_annotations)
                 progress_stats = f'{len(temp_incompleted_anns)}/{total_incompleted_anns}'
                 temp_incompleted_anns.insert(0, progress_stats)
                 temp_incompleted_anns.insert(1, project)


### PR DESCRIPTION
This change fixes the errors in the number on the "Current Assignment" page. There were two problems:
1. The incomplete annotations had an extra row if you expand each record since the index it was referring to in the template was incorrect
2. The total number of annotations was incorrect since it did not take into account the assigned annotations to the user