### PR TITLE
Prevents empty user assignments

### DIFF
--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -67,9 +67,10 @@ def update_assignments(csv_data, project_folder):
         csvwriter = csv.writer(csv_file)
         csvwriter.writerow(['Events', 'Users Assigned'])
         for key, val in csv_data.items():
-            row = [key]
-            row.extend(val)
-            csvwriter.writerows([row])
+            if len(val) > 0:
+                row = [key]
+                row.extend(val)
+                csvwriter.writerows([row])
 
 
 def get_all_assignments(project_folder):


### PR DESCRIPTION
This change prevents events with no users assigned to them from being saved to the `user_annotations.csv` file. Steps to re-create this bug are:
1. Assign yourself annotations
2. Check the `user_annotations.csv` file and it should still be populated with the assigned events and with your username assigned to each
2. Revoke your annotations
3. Check the `user_annotations.csv` file and it should still be populated with the assigned events but this time with no users assigned to each