### PR TITLE
Removes uncertain / clarifies language

### DIFF
--- a/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
+++ b/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
@@ -88,7 +88,7 @@ app.layout = html.Div([
                 options = [
                     {'label': 'True (alarm is correct)', 'value': 'True'},
                     {'label': 'False (alarm is incorrect)', 'value': 'False'},
-                    {'label': 'Uncertain / Save for later', 'value': 'Uncertain'}
+                    {'label': 'Save for Later', 'value': 'Save for Later'}
                 ],
                 labelStyle = {'display': 'block'},
                 style = {'width': sidebar_width,},

--- a/waveform-django/waveforms/templates/waveforms/annotations.html
+++ b/waveform-django/waveforms/templates/waveforms/annotations.html
@@ -66,18 +66,28 @@
         <label for="num_events">Number of events to assign:</label>
         <input id="num_events" type="number" name="num_events" value="100" min="100" max="800" required
               value="Must assign at least 100 events">
-        <br>
+        <br />
         <input type="submit" name="new_assignment" class="btn btn-primary btn-rsp" value="Submit">
       </form>
     {% else %}
-      <h2>Current Assignment</h2>
-      <span style="font-size: 20px; float: left;">Remaining Events: </span>
-      <span style="font-size: 20px; float: right;">{{ remaining }}</span>
+      <form action="" method="post">
+        {% csrf_token %}
+        <h2>Annotate More Events</h2>
+        <label for="num_events">Number of events to assign:</label>
+        <input id="num_events" type="number" name="num_events" value="100" min="100" max="800" required
+              value="Must assign at least 100 events" disabled>
+        <br />
+        <input type="submit" name="new_assignment" class="btn btn-primary btn-rsp" value="Submit" disabled>
+        <label>*** All annotations must either be True or False, no Save for Later ***</label>
+      </form>
     {% endif %}
-    <br><br>
+    <h2>Current Assignment</h2>
+    <span style="font-size: 20px; float: left;">Remaining Events: </span>
+    <span style="font-size: 20px; float: right;">{{ remaining }}</span>
+    <br /><br />
   </div>
-  <div><h2>Uncertain / Saved Annotations</h2></div>
-  {% for rec,info in uncertain_anns.items %}
+  <div><h2>Save for Later Annotations</h2></div>
+  {% for rec,info in saved_anns.items %}
     <button class="accordion">
       <span style="float: left;">{{ info.1 }}:&emsp;{{ rec }}</span>
       <span style="float: right;">{{ info.0 }}</span>

--- a/waveform-django/waveforms/templates/waveforms/tutorial.html
+++ b/waveform-django/waveforms/templates/waveforms/tutorial.html
@@ -34,7 +34,7 @@
     <li>Below that, you should see links to <a href="{% url 'render_annotations' %}">view your current annotations</a>, view a brief tutorial explaining the layout of the annotator (this page), and <a href="{% url 'viewer_settings' %}">a way to change the settings / preferences of your annotator</a> (including grid color, time before and after an event, the level of downsampling, etc.).</li>
     <li>To begin annotating, go to the <a href="{% url 'waveform_published_home' %}">annotator home</a> and scroll down to view the entire annotator.
     <li>On the top left side, you should see the name of the current annotation record, event, and label (It has been filtered so only VTach and VFib/VFlutter events are displayed. Please let us know if you see otherwise!).</li>
-    <li>Directly below this is where you can enter your decision for the label (True, False, or Uncertain) as well as your additional comments explaining your decision (this field is not necessary but may prove useful later on for either self-reference or research purposes).</li>
+    <li>Directly below this is where you can enter your decision for the label (True, False, or Save for Later) as well as your additional comments explaining your decision (this field is not necessary but may prove useful later on for either self-reference or research purposes).</li>
     <li>You can submit the annotation with the "Submit" button, or go to the next or previous annotation without saving using the arrows. Submitting the annotation will automatically send you to the next event.</li>
     <li>If you hover over the signals, you will be able to see its value and how it aligns with the other signals.</li>
     <li>Also, you can click and drag the signal in any direction to view more of it.</li>

--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -369,14 +369,14 @@ def render_annotations(request):
                                                                  'False'])
     completed_records = [a.record for a in completed_annotations]
     completed_events = [a.event for a in completed_annotations]
-    # Uncertain / saved annotations
-    uncertain_annotations = all_annotations.filter(decision='Uncertain')
-    uncertain_records = [a.record for a in uncertain_annotations]
-    uncertain_events = [a.event for a in uncertain_annotations]
+    # Saved annotations
+    saved_annotations = all_annotations.filter(decision='Save for Later')
+    saved_records = [a.record for a in saved_annotations]
+    saved_events = [a.event for a in saved_annotations]
 
     # Hold all of the annotation information
     completed_anns = {}
-    uncertain_anns = {}
+    saved_anns = {}
     incompleted_anns = {}
 
     # Get list where each element is a list of records from a project folder
@@ -411,7 +411,7 @@ def render_annotations(request):
 
             # Add annotations by event
             temp_completed_anns = []
-            temp_uncertain_anns = []
+            temp_saved_anns = []
             temp_incompleted_anns = []
             for evt in temp_events:
                 if (rec in completed_records) and (evt in completed_events):
@@ -420,9 +420,9 @@ def render_annotations(request):
                                                 ann.decision,
                                                 ann.comments,
                                                 ann.decision_date])
-                elif (rec in uncertain_records) and (evt in uncertain_events):
-                    ann = uncertain_annotations[uncertain_events.index(evt)]
-                    temp_uncertain_anns.append([ann.event,
+                elif (rec in saved_records) and (evt in saved_events):
+                    ann = saved_annotations[saved_events.index(evt)]
+                    temp_saved_anns.append([ann.event,
                                                 ann.decision,
                                                 ann.comments,
                                                 ann.decision_date])
@@ -435,11 +435,11 @@ def render_annotations(request):
                 temp_completed_anns.insert(0, progress_stats)
                 temp_completed_anns.insert(1, project)
                 completed_anns[rec] = temp_completed_anns
-            if temp_uncertain_anns != []:
-                progress_stats = f'{len(temp_uncertain_anns)}/{len(temp_events)}'
-                temp_uncertain_anns.insert(0, progress_stats)
-                temp_uncertain_anns.insert(1, project)
-                uncertain_anns[rec] = temp_uncertain_anns
+            if temp_saved_anns != []:
+                progress_stats = f'{len(temp_saved_anns)}/{len(temp_events)}'
+                temp_saved_anns.insert(0, progress_stats)
+                temp_saved_anns.insert(1, project)
+                saved_anns[rec] = temp_saved_anns
             if temp_incompleted_anns != []:
                 progress_stats = f'{len(temp_incompleted_anns)}/{len(temp_events)}'
                 temp_incompleted_anns.insert(0, progress_stats)
@@ -508,7 +508,7 @@ def render_annotations(request):
     return render(request, 'waveforms/annotations.html',
                   {'user': user, 'all_anns_frac': all_anns_frac,
                    'categories': categories, 'completed_anns': completed_anns,
-                   'uncertain_anns': uncertain_anns,
+                   'saved_anns': saved_anns,
                    'incompleted_anns': incompleted_anns,
                    'finished_assignment': finished_assignment,
                    'remaining': total_anns - len(completed_annotations)})
@@ -561,7 +561,7 @@ def leaderboard(request):
     glob_true = []
     glob_false = []
     for user in all_users:
-        user_anns = Annotation.objects.filter(user=user).exclude(decision='Uncertain')
+        user_anns = Annotation.objects.filter(user=user).exclude(decision='Save for Later')
         num_today = 0
         num_week = 0
         num_month = 0


### PR DESCRIPTION
This change removes the "Uncertain" language on the "Save for Later" button to require annotators to complete all annotations with either a "True" or "False" in order to assign. It also keeps the "assign more annotations" form even when the user is not able to complete it to keep the page consistent.