### PR TITLE
Makes rangeslider more intuitive

### DIFF
--- a/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
+++ b/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
@@ -500,7 +500,7 @@ def get_xaxis(vals, grid_delta_major, show_ticks, title, zoom_fixed, grid_color,
         'rangeslider': {
             'visible': show_ticks,
             'thickness': 0.025,
-            'bgcolor': 'rgb(0,0,0)'
+            'bgcolor': 'rgb(255,255,255)'
         },
         'showspikes': True,
         'spikemode': 'across',


### PR DESCRIPTION
This change makes the `rangeslider` more intuitive by displaying a summary of the signals and while also changing colors between the current window and available window to be displayed.