### PR TITLE
Fixes user assignment error

### DIFF
--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -69,10 +69,10 @@ def update_assignments(csv_data, project_folder):
     with open(csv_path, 'w', newline='', encoding='utf-8') as csv_file:
         csvwriter = csv.writer(csv_file)
         csvwriter.writerow(['Events', 'Users Assigned'])
-        for key, val in csv_data.items():
-            if len(val) > 0:
-                row = [key]
-                row.extend(val)
+        for event,user in csv_data.items():
+            if len(user) > 0:
+                row = [event]
+                row.extend([user])
                 csvwriter.writerows([row])
 
 


### PR DESCRIPTION
This change fixes a  pesky bug where usernames greater than 1 character in length are written to the `user_assignments.csv` file as:
```
Events,User Assigned
111,l,u,c,a,s
222,l,u,c,a,s
...
```
instead of:
```
Events,User Assigned
111,lucas
222,lucas
...
```
Wow, now I learn to test using usernames with >1 character 😝 