### PR TITLE
Adds basic caliper

### DIFF
--- a/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
+++ b/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
@@ -38,6 +38,10 @@ arrow_width = str(float(submit_width.split('px')[0]) / 2 + 3) + 'px'
 # Set the default configuration of the plot top buttons
 plot_config = {
     'displayModeBar': True,
+    'modeBarButtonsToAdd': [
+        'drawline',
+        'eraseshape'
+    ],
     'modeBarButtonsToRemove': [
         'hoverClosestCartesian',
         'hoverCompareCartesian',
@@ -345,6 +349,12 @@ def get_layout(fig_height, fig_width, margin_left, margin_top, margin_right,
         'showlegend': False,
         'hovermode': 'x',
         'dragmode': drag_mode,
+        'newshape': {
+            'line': {
+                'color': 'black',
+                'width': 10
+            }
+        },
         'spikedistance':  -1,
         'plot_bgcolor': background_color,
         'paper_bgcolor': '#ffffff',


### PR DESCRIPTION
This change adds a basic caliper functionality to compare peak distances between EKG pulses. To do so, there is now a "Draw Line" icon at the top of the figure which you can click then click and drag your mouse to create a line. You can then click on the line and drag it to each peak to compare the distances. If you don't like it, you can either resize it using the circles on either side of the line or delete it using the "Erase Active Shape" button.