### PR TITLE
Adds email notifications for admins

### DIFF
--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -235,7 +235,7 @@ def admin_console(request):
             invite_user_form = InviteUserForm(request.POST)
             if invite_user_form.is_valid():
                 invite_user_form.save(
-                    from_email='help@waveform-annotation.com',
+                    from_email=base.EMAIL_FROM,
                     request=request
                 )
                 messages.success(request,

--- a/waveform-django/website/forms.py
+++ b/waveform-django/website/forms.py
@@ -82,8 +82,8 @@ class ResetPasswordForm(forms.Form):
     def save(self, domain_override=None,
              subject_template_name='registration/password_reset_subject.txt',
              email_template_name='registration/password_reset_email.html',
-             use_https=False, from_email=None, request=None,
-             html_email_template_name=None, extra_email_context=None):
+             from_email=None, request=None, html_email_template_name=None,
+             extra_email_context=None):
         """
         Generate a one-use only link for resetting password and send it to the
         user.
@@ -106,7 +106,7 @@ class ResetPasswordForm(forms.Form):
             'uid': urlsafe_base64_encode(force_bytes(user.pk)),
             'user': user,
             'token': password_reset_token.make_token(user),
-            'protocol': 'https' if use_https else 'http',
+            'protocol': 'http' if domain.startswith('localhost') else 'https',
             **(extra_email_context or {}),
         }
         self.send_mail(

--- a/waveform-django/website/settings/base.py
+++ b/waveform-django/website/settings/base.py
@@ -43,6 +43,7 @@ EMAIL_PORT = config('EMAIL_PORT', default=1025, cast=int)
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 EMAIL_USE_TLS = False
+EMAIL_FROM = 'help@waveform-annotation.com'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/

--- a/waveform-django/website/templates/registration/new_invite_email.html
+++ b/waveform-django/website/templates/registration/new_invite_email.html
@@ -1,0 +1,13 @@
+{% autoescape off %}
+
+A new user has recently been invited with email: {{ email }}!
+You can find more details here:
+
+{{ protocol }}://{{ domain }}{% url 'admin_console' %}
+
+Thank you for your continued support!
+
+Sincerely,
+The MIT VT/VF Annotation Team
+
+{% endautoescape %}

--- a/waveform-django/website/templates/registration/new_invite_subject.txt
+++ b/waveform-django/website/templates/registration/new_invite_subject.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}New user invited {{ site_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/waveform-django/website/templates/registration/new_user_email.html
+++ b/waveform-django/website/templates/registration/new_user_email.html
@@ -1,0 +1,13 @@
+{% autoescape off %}
+
+A new user has recently joined with email: {{ email }}!
+You can find more details here:
+
+{{ protocol }}://{{ domain }}{% url 'admin_console' %}
+
+Thank you for your continued support!
+
+Sincerely,
+The MIT VT/VF Annotation Team
+
+{% endautoescape %}

--- a/waveform-django/website/templates/registration/new_user_subject.txt
+++ b/waveform-django/website/templates/registration/new_user_subject.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}New user joined {{ site_name }}{% endblocktrans %}
+{% endautoescape %}


### PR DESCRIPTION
This change does three things:
1. Cleans the existing email functionalities by clarifying `https` usage and adding the send-from email to the settings.
2. Notifies admins when a new user joins.
3. Notifies admins when a new user is invited.