### PR TITLE
Fixes current assignment warning

### DIFF
--- a/waveform-django/waveforms/templates/waveforms/annotations.html
+++ b/waveform-django/waveforms/templates/waveforms/annotations.html
@@ -50,23 +50,14 @@
           <input type="submit" name="new_assignment" class="btn btn-primary btn-rsp" value="Submit">
         </form>
       {% else %}
-        <form action="" method="post">
-          {% csrf_token %}
-          <h2>Annotate More Events</h2>
-          <label for="num_events">Number of events to assign:</label>
-          <input id="num_events" type="number" name="num_events" value="100" min="100" max="800" required
-                value="Must assign at least 100 events" disabled>
-          <br />
-          <label class="label-warning">
-            ***
-            Please complete your current assignment to continue.
-            All annotations must either be <u>True</u>, <u>False</u>, or <u>Uncertain</u>.
-            There can be no annotations which are <u>Save for Later</u>.
-            ***
-          </label>
-          <br />
-          <input type="submit" name="new_assignment" class="btn btn-primary btn-rsp" value="Submit" disabled>
-        </form>
+          {% if save_warning %}
+            <label class="label-warning">
+              ***
+              There can be no annotations which are <u>Save for Later</u>.
+              All annotations must either be <u>True</u>, <u>False</u>, or <u>Uncertain</u>.
+              ***
+            </label>
+          {% endif %}
       {% endif %}
     {% endif %}
     <br />

--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -410,6 +410,7 @@ def render_annotations(request):
     saved_annotations = all_annotations.filter(decision='Save for Later')
     saved_records = [a.record for a in saved_annotations]
     saved_events = [a.event for a in saved_annotations]
+    save_warning = len(saved_annotations) > 0
 
     # Hold all of the annotation information
     completed_anns = {}
@@ -580,7 +581,8 @@ def render_annotations(request):
                    'saved_anns': saved_anns,
                    'incompleted_anns': incompleted_anns,
                    'finished_assignment': finished_assignment,
-                   'remaining': total_anns - len(completed_annotations)})
+                   'remaining': total_anns - len(completed_annotations),
+                   'save_warning': save_warning})
 
 
 @login_required


### PR DESCRIPTION
This change fixes the warning on the Current Assignment page to be less disruptive. Previously, it displays any time the user has not completed their assignment but this change fixes it so that they are now only warned when they have saved an annotation as Save for Later.