### PR TITLE
Added event stats tracker to leaderboard

### DIFF
--- a/waveform-django/waveforms/templates/waveforms/leaderboard.html
+++ b/waveform-django/waveforms/templates/waveforms/leaderboard.html
@@ -196,6 +196,31 @@
   <br><br>
   <h1>Global Leaderboard</h1>
   <br>
+    <div class="row">
+    <div class="column">
+      <table class="stats">
+        <tr>
+          <th colspan="3" style="background-color: rgba(122,20,255,0.23)">
+            <h2>
+              <span style="float: left;">Completed Events:</span>
+              <span style="float: right;">{{ two_anns }}</span>
+            </h2></th>
+        </tr>
+      </table>
+    </div>
+    <div class="column">
+      <table class="stats">
+        <tr>
+          <th colspan="3" style="background-color: rgba(122,20,255,0.23)">
+            <h2>
+              <span style="float: left;">Events in Progress:</span>
+              <span style="float: right;">{{ one_ann }}</span>
+            </h2></th>
+        </tr>
+      </table>
+    </div>
+  </div>
+  <br>
   <div class="row">
     <div class="column">
       <table class="stats">


### PR DESCRIPTION
The number of events with two annotators and the number of events with one annotator can now be viewed on the leaderboard page.