### PR TITLE
Fixes adjudication caliper

### DIFF
--- a/waveform-django/waveforms/templates/waveforms/adjudicator_console.html
+++ b/waveform-django/waveforms/templates/waveforms/adjudicator_console.html
@@ -7,6 +7,9 @@
     width: 1200px;
     height: 745px;
 }
+.ui-resizable-e {
+  width: 50%;
+}
 .float-left-no-pad {
   float: left;
   margin: 0;
@@ -117,7 +120,7 @@ function displayCaliper() {
     caliper_wrapper.style.display = "inline-block";
     caliper_wrapper.style.position = "absolute";
     caliper_wrapper.style.left = "89%";
-    caliper_wrapper.style.top = "20%";
+    caliper_wrapper.style.top = "35%";
     caliper_wrapper.style.padding = "25px";
     caliper_resize.style.height = "100px";
     caliper_resize.style.width = "80px";


### PR DESCRIPTION
This change fixes the initial display position of the caliper and increases the margin allowing it to be stretched to the same as the typical waveform viewer.