### PR TITLE
Adds cronjob / fixes local static

### DIFF
--- a/backups/README.md
+++ b/backups/README.md
@@ -1,0 +1,1 @@
+# Will store all of the backups for the annotations

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,8 @@ python-decouple==3.1 \
  --hash=sha256:1317df14b43efee4337a4aa02914bf004f010cd56d6c4bd894e6474ec8c4fe2d
 pytz==2018.3 \
  --hash=sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd
+django-crontab==0.7.1 \
+ --hash=sha256:1201810a212460aaaa48eb6a766738740daf42c1a4f6aafecfb1525036929236
 
 #### Requirements for development and testing ####
 

--- a/waveform-django/cron.py
+++ b/waveform-django/cron.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+import os
+
+import pandas as pd
+
+from waveforms.models import Annotation
+from website.settings import base
+
+
+def update_annotations():
+    # Update the annotation CSV file each night at midnight.
+    all_anns = Annotation.objects.filter(is_adjudication=False)
+    csv_df = pd.DataFrame.from_dict({
+        'username': [a.user.username for a in all_anns],
+        'dataset' : [a.project for a in all_anns],
+        'record': [a.record for a in all_anns],
+        'event': [a.event for a in all_anns],
+        'decision': [a.decision for a in all_anns],
+        'comment': [a.comments for a in all_anns],
+        'date': [str(a.decision_date) for a in all_anns]
+    })
+    file_name = datetime.now().strftime('all-anns_%H_%M_%d_%m_%Y.csv')
+    out_file = os.path.join(base.HEAD_DIR, 'backups', file_name)
+    csv_df.to_csv(out_file, sep=',', index=False)

--- a/waveform-django/website/settings/base.py
+++ b/waveform-django/website/settings/base.py
@@ -53,6 +53,7 @@ SECRET_KEY = config('SECRET_KEY')
 # Application definition
 
 INSTALLED_APPS = [
+    'django_crontab',
     'debug_toolbar',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -91,6 +92,17 @@ DATABASES = {
         'NAME': os.path.join(HEAD_DIR,'db','db.sqlite3')
     }
 }
+
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+CRONJOBS = [
+    ('0 0 * * *', 'waveform-django.cron.update_annotations')
+]
 
 ROOT_URLCONF = 'website.urls'
 
@@ -191,7 +203,7 @@ MAX_ATTEMPTS = 5
 
 if DEBUG:
     STATIC_URL = '/static/'
-    STATIC_ROOT = 'static'
+    STATIC_ROOT = 'assets'
     STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 else:
     STATIC_URL = '/waveform-annotation/static/'


### PR DESCRIPTION
This change adds a `cronjob` to automatically download the latest annotations as a CSV file at midnight each night. Currently, it will only do the non-adjudicated ones but a future not-to-distant change will adjust this. I also fixed a bug in the static file delivery for `localhost` where the `STATIC_ROOT` was duplicated and I didn't realize because it was feeding off of my caches.