### PR TITLE
Adds functioning adjudicator console

### DIFF
--- a/waveform-django/cron.py
+++ b/waveform-django/cron.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import os
 
 import pandas as pd
+import pytz
 
 from waveforms.models import Annotation
 from website.settings import base
@@ -19,6 +20,6 @@ def update_annotations():
         'comment': [a.comments for a in all_anns],
         'date': [str(a.decision_date) for a in all_anns]
     })
-    file_name = datetime.now().strftime('all-anns_%H_%M_%d_%m_%Y.csv')
+    file_name = datetime.now(pytz.timezone(base.TIME_ZONE)).strftime('all-anns_%H_%M_%d_%m_%Y.csv')
     out_file = os.path.join(base.HEAD_DIR, 'backups', file_name)
     csv_df.to_csv(out_file, sep=',', index=False)

--- a/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
+++ b/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
@@ -810,9 +810,9 @@ def window_signal(y_vals):
      dash.dependencies.Output('dropdown_event', 'children'),
      dash.dependencies.Output('dropdown_project', 'children'),
      dash.dependencies.Output('event_text', 'children'),
+     dash.dependencies.Output('temp_project', 'value'),
      dash.dependencies.Output('temp_record', 'value'),
-     dash.dependencies.Output('temp_event', 'value'),
-     dash.dependencies.Output('temp_project', 'value')],
+     dash.dependencies.Output('temp_event', 'value')],
     [dash.dependencies.Input('submit_annotation', 'n_clicks_timestamp'),
      dash.dependencies.Input('previous_annotation', 'n_clicks_timestamp'),
      dash.dependencies.Input('next_annotation', 'n_clicks_timestamp'),
@@ -908,14 +908,14 @@ def get_record_event_options(click_submit, click_previous, click_next,
                 current_event = all_indices[0]
             else:
                 current_event = 0
+            return_project = all_events[current_event][0]
             return_record = all_events[current_event][1].split('_')[0]
             return_event = all_events[current_event][1]
-            return_project = all_events[current_event][0]
         else:
             # Display empty graph since no data
+            return_project = 'N/A'
             return_record = 'N/A'
             return_event = 'N/A'
-            return_project = 'N/A'
     else:
         completed_events = [a.event for a in user_annotations if a.project==project_value]
         if current_user.is_admin and current_user.practice_status == 'ED':
@@ -1035,7 +1035,7 @@ def get_record_event_options(click_submit, click_previous, click_next,
     ]
 
     return (record_text, event_text, project_text, alarm_text,
-            return_record, return_event, return_project)
+            return_project, return_record, return_event)
 
 
 @app.callback(

--- a/waveform-django/waveforms/templates/waveforms/adjudicator_console.html
+++ b/waveform-django/waveforms/templates/waveforms/adjudicator_console.html
@@ -5,110 +5,25 @@
 <style>
 .embed-responsive {
     width: 1200px;
-    height: 745px;
+    height: 780px;
 }
 .ui-resizable-e {
   width: 50%;
 }
-.float-left-no-pad {
-  float: left;
-  margin: 0;
-}
-.float-right-no-pad {
-  float: right;
-  margin: 0;
-}
 </style>
 
+<!-- Plotly-based waveform viewer -->
 <div class="container">
-  <!-- All possible adjudication annotations -->
   <h1>Adjudicator Console</h1>
-  <!-- The current annotation being adjudicated -->
-  {% for project,k in top_anns.items %}
-    {% for rec,info in k.items %}
-      {% for glob,nfo in info.items %}
-        <h5 class="float-left-no-pad">Current Adjudication: {{ project }}, {{ rec }}, {{ glob.0 }}</h5>
-        <table style="width:100%">
-          <tr>
-            {% for cat in categories|slice:":3" %}
-              <th>
-                {{ cat }}
-              </th>
-            {% endfor %}
-          </tr>
-          {% for val in nfo.0 %}
-            <tr>
-              {% for v in val|slice:":3" %}
-                <td>
-                  {{ v }}
-                </td>
-              {% endfor %}
-            </tr>
-          {% endfor %}
-        </table>
-      {% endfor %}
-    {% endfor %}
-  {% endfor %}
   <!-- The caliper -->
   <input type="button" value="Show/Hide Caliper" style="float: right" onclick="displayCaliper();"/>
   <div id="caliper_drag_wrapper" style="display: none; position: absolute; z-index: 10000; padding: 25px;">
     <img src="{% static "caliper.png" %}" alt="Caliper" id="caliper_drag" style="cursor: pointer; height: 100px; width: 80px;"/>
   </div>
   <!-- The graph -->
-  {% plotly_app_bootstrap name='waveform_graph_adjudicate' initial_arguments=dash_context %}
-  <!-- The annotations -->
-  <br />
-  {% for project,k in reviewed_anns.items %}
-    <h2>Project: {{ project }}</h2>
-    <h3><u>Conflicting Annotations</u></h3>
-    {% for rec,info in k.items %}
-      {% if info|length > 0 %}
-        <h4 class="float-left-no-pad">Record: {{ rec }}</h4><br /><br />
-        {% for glob,nfo in info.items %}
-          <h5 class="float-left-no-pad">Event: {{ glob.0 }} (<a href="{% url 'waveform_published_specific_adjudicate' project rec glob.0 %}">Adjudicate annotation</a>)</h5>
-          <h5 class="float-right-no-pad">Annotated: {{ glob.1 }}</h5><br />
-          {% if glob.2 == False %}
-            <h5 class="float-right-no-pad" style="color: red;">Not Adjudicated</h5>
-          {% else %}
-            <h5 class="float-right-no-pad" style="color: green">Adjudicated</h5>
-          {% endif %}
-          <table style="width:100%">
-            <tr>
-              {% for cat in categories %}
-                <th>
-                  {{ cat }}
-                </th>
-              {% endfor %}
-            </tr>
-            {% for val in nfo.0 %}
-              <tr>
-                {% for v in val %}
-                  <td>
-                    {{ v }}
-                  </td>
-                {% endfor %}
-              </tr>
-            {% endfor %}
-            {% if nfo.1 %}
-              <tr><td>Adjudication</td></tr>
-              {% for val in nfo.1 %}
-                <tr>
-                  {% for v in val %}
-                    <td>
-                      {{ v }}
-                    </td>
-                  {% endfor %}
-                </tr>
-              {% endfor %}
-            {% endif %}
-          </table><br />
-        {% endfor %}
-        <br />
-      {% endif %}
-    {% endfor %}
-  {% endfor %}
-  <br />
-
+  <div>
+    {% plotly_app_bootstrap name='waveform_graph_adjudicate' initial_arguments=dash_context %}
+  </div>
 </div>
 
 <script type="text/javascript">

--- a/waveform-django/waveforms/templates/waveforms/annotations.html
+++ b/waveform-django/waveforms/templates/waveforms/annotations.html
@@ -134,7 +134,7 @@
         <a href="{% url 'render_annotations' %}?saved_page=1#saved_annotations">Show pages</a>
       {% else %}
         <a href="{% url 'render_annotations' %}?saved_page=all#saved_annotations">Show all</a>
-      {% endif %}  
+      {% endif %}
     </div>
     {% endif %}
   {% for rec,info in saved_anns.items %}
@@ -239,7 +239,7 @@
       {% if incomplete_page.has_next %}
         <a href="{% url 'render_annotations' %}?incomplete_page={{ incomplete_page.next_page_number}}#incomplete_annotations">Next Page</a>&emsp;
       {% endif %}
-      
+
       {% if request.GET.incomplete_page == 'all' %}
         <a href="{% url 'render_annotations' %}?incomplete_page=1#incomplete_annotations">Show pages</a>
       {% else %}


### PR DESCRIPTION
This change adds a functioning adjudication console. This change will allow pre-approved adjudicators to adjudicate waveforms which are completed (i.e., has at least two annotations) and conflicting (i.e., there is at least one decision disagreement between the completed annotation). This will show up as an `Adjudicator Console` tab at the top of the page.

It is assumed that the user would work together with fellow adjudicators to work through the conflicting events. At the top of the console will be all of the annotations for the given event. The adjudicator has the choice to mark the event as `True`, `False`, or `Uncertain` (meaning throw it out since it can't be determined --- *I don't actually throw it out*). Once the choice is made, a popup dialog will be displayed to confirm the choice made. If `Cancel` is chosen, nothing will happen and if `OK` is chosen, the adjudication will be created and the viewer will move to the next annotation. Completed adjudications can be seen on the admin console but I am planning on moving it somewhere easier next.