### PR TITLE
Double adjudicate / sorted / editable

### DIFF
--- a/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
+++ b/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
@@ -963,15 +963,14 @@ def get_record_event_options(click_submit, click_previous, click_next,
             # were made or a new annotation
             try:
                 res = Annotation.objects.get(user=current_user,
-                                             project=return_project,
+                                             project=project_value,
+                                             record=record_value,
                                              event=event_value,
                                              is_adjudication=False)
-                current_annotation = [res.project, res.record, res.event,
-                                      res.decision, res.comments]
-                proposed_annotation = [project_value, event_value,
-                                       decision_value, comments_value]
+                current_annotation = [res.decision, res.comments]
+                proposed_annotation = [decision_value, comments_value]
                 # Only save annotation if something has changed
-                if current_annotation[:4] != proposed_annotation:
+                if current_annotation != proposed_annotation:
                     annotation = Annotation(
                         user = current_user,
                         project = project_value,
@@ -979,7 +978,8 @@ def get_record_event_options(click_submit, click_previous, click_next,
                         event = event_value,
                         decision = decision_value,
                         comments = comments_value,
-                        decision_date = submit_time
+                        decision_date = submit_time,
+                        is_adjudication=False
                     )
                     annotation.update()
             except Annotation.DoesNotExist:
@@ -991,7 +991,8 @@ def get_record_event_options(click_submit, click_previous, click_next,
                     event = event_value,
                     decision = decision_value,
                     comments = comments_value,
-                    decision_date = submit_time
+                    decision_date = submit_time,
+                    is_adjudication=False
                 )
                 annotation.update()
     else:

--- a/waveform-django/waveforms/templates/waveforms/adjudications.html
+++ b/waveform-django/waveforms/templates/waveforms/adjudications.html
@@ -26,6 +26,9 @@
           {% endfor %}
           <!-- Assuming only one adjudication per project, record, and event -->
           <th>
+            <a href="{% url 'waveform_published_specific_adjudicate' batch.0.0 batch.0.1 batch.0.2 %}">Edit adjudication</a>
+          </th>
+          <th>
             <a href="{% url 'delete_adjudication' batch.0.0 batch.0.1 batch.0.2 %}">Delete adjudication</a>
           </th>
         </tr>

--- a/waveform-django/waveforms/templates/waveforms/adjudicator_console.html
+++ b/waveform-django/waveforms/templates/waveforms/adjudicator_console.html
@@ -5,7 +5,7 @@
 <style>
 .embed-responsive {
     width: 1200px;
-    height: 800px;
+    height: 820px;
 }
 .ui-resizable-e {
   width: 50%;

--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -485,7 +485,7 @@ def render_adjudications(request):
         return redirect('waveform_published_home')
 
     # Get info of all non-adjudicated annotations assuming non-unique event names
-    non_adjudicated_anns = Annotation.objects.filter(is_adjudication=False).values('project','record','event')
+    non_adjudicated_anns = Annotation.objects.filter(is_adjudication=False).order_by('-decision_date').values('project','record','event')
     all_info = [tuple(ann.values()) for ann in non_adjudicated_anns]
     unique_anns = Counter(all_info).keys()
     ann_counts = Counter(all_info).values()
@@ -511,13 +511,13 @@ def render_adjudications(request):
             if is_conflicting:
                 conflicting_anns.append(c)
                 # Add the unfinished adjudications
-                temp_anns = all_anns.values('project', 'record', 'event',
-                                            'user__username', 'decision',
-                                            'comments', 'decision_date')
+                temp_anns = all_anns.values(
+                    'project', 'record', 'event', 'user__username', 'decision', 'comments', 'decision_date'
+                )
                 unfinished_adjudications.append([list(ann.values()) for ann in temp_anns])
 
     # Get info of all adjudicated annotations
-    adjudicated_anns = Annotation.objects.filter(is_adjudication=True)
+    adjudicated_anns = Annotation.objects.filter(is_adjudication=True).order_by('-decision_date')
     # Collect the finished adjudications
     finished_adjudications = []
     for current_ann in adjudicated_anns:


### PR DESCRIPTION
This change allows for adjudications to be edited and, by doing so, I removed the possibility for one to be adjudicated twice. Further, I sorted the adjudicates by most recent on the View Adjudications page.