### PR TITLE
Fixes CSS to be relative / improves graph display

### DIFF
--- a/waveform-django/templates/base.html
+++ b/waveform-django/templates/base.html
@@ -11,6 +11,27 @@
       button.btn.btn-outline-primary:hover a{
         color: white;
       }
+      /* Override default bootstrap CSS */
+      @media (min-width: 576px) {
+        .container {
+          max-width: 90%;
+        }
+      }
+      @media (min-width: 768px) {
+        .container {
+          max-width: 90%;
+        }
+      }
+      @media (min-width: 992px) {
+        .container {
+          max-width: 90%;
+        }
+      }
+      @media (min-width: 1200px) {
+        .container {
+          max-width: 90%;
+        }
+      }
     </style>
     {% endblock %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
+++ b/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis.py
@@ -28,15 +28,17 @@ FILE_LOCAL = os.path.join('record-files')
 PROJECT_PATH = os.path.join(FILE_ROOT, FILE_LOCAL)
 ALL_PROJECTS = base.ALL_PROJECTS
 # Formatting settings
-sidebar_width = '210px'
-event_fontsize = '24px'
-comment_box_height = '255px'
-label_fontsize = '20px'
-button_height = '35px'
-submit_width = str(float(sidebar_width.split('px')[0]) / 2) + 'px'
-arrow_width = str(float(submit_width.split('px')[0]) / 2 + 3) + 'px'
+sidebar_width = '100%'
+event_fontsize = '100%'
+comment_box_width = '90%'
+comment_box_height = '30vh'
+label_fontsize = '100%'
+button_height = '10%'
+submit_width = '49%'
+arrow_width = '23%'
 # Set the default configuration of the plot top buttons
 plot_config = {
+    'responsive': True,
     'displayModeBar': True,
     'modeBarButtonsToAdd': [
     ],
@@ -105,7 +107,7 @@ app.layout = html.Div([
             html.Div(
                 dcc.Textarea(id='reviewer_comments',
                              style={
-                                'width': sidebar_width,
+                                'width': comment_box_width,
                                 'height': comment_box_height,
                                 'font-size': label_fontsize
                              })
@@ -127,13 +129,14 @@ app.layout = html.Div([
                         style={'height': button_height,
                                'width': arrow_width,
                                'font-size': 'large'}),
-        ], style={'display': 'inline-block', 'vertical-align': '35px',
-                    'padding-right': '10px'}),
+        ], style={'display': 'inline-block', 'vertical-align': 'top',
+                    'padding-top': '2%'}),
         # The plot itself
         html.Div([
             dcc.Graph(
                 id='the_graph',
-                config=plot_config
+                config=plot_config,
+                style={'height': '75vh', 'width': '80vw'}
             ),
         ], style={'display': 'inline-block'})
     ], type='default'),
@@ -372,8 +375,8 @@ def get_layout(fig_height, fig_width, margin_left, margin_top, margin_right,
 
     """
     return {
-        'height': fig_height,
-        'width': fig_width,
+        # 'height': fig_height,
+        # 'width': fig_width,
         'margin': {'l': margin_left,
                    't': margin_top,
                    'r': margin_right,

--- a/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis_adjudicate.py
+++ b/waveform-django/waveforms/dash_apps/finished_apps/waveform_vis_adjudicate.py
@@ -27,13 +27,14 @@ FILE_LOCAL = os.path.join('record-files')
 PROJECT_PATH = os.path.join(FILE_ROOT, FILE_LOCAL)
 ALL_PROJECTS = base.ALL_PROJECTS
 # Formatting settings
-annotations_width = '1100px'
-sidebar_width = '210px'
-event_fontsize = '24px'
-comment_box_height = '180px'
-label_fontsize = '20px'
-button_height = '30px'
-button_width = str(float(sidebar_width.split('px')[0]) / 2) + 'px'
+annotations_width = '100%'
+sidebar_width = '14.58%'
+event_fontsize = '100%'
+comment_box_width = '90%'
+comment_box_height = '15vh'
+label_fontsize = '100%'
+button_height = '10%'
+button_width = '50%'
 # Set the default configuration of the plot top buttons
 plot_config = {
     'displayModeBar': True,
@@ -103,6 +104,18 @@ app.layout = html.Div([
                 children=html.Span([''], style={'fontSize': event_fontsize})
             ),
             # Submit annotation decision and comments
+            # The reviewer comment section
+            html.Label(['Enter comments here:'],
+                       style={'font-size': label_fontsize}),
+            html.Div(
+                dcc.Textarea(id='reviewer_comments',
+                             style={
+                                'width': comment_box_width,
+                                'height': comment_box_height,
+                                'font-size': label_fontsize
+                             })
+            ),
+            html.Br(),
             # For warning the user of their decision
             html.Div(id='output-provider'),
             dcc.ConfirmDialogProvider(
@@ -145,30 +158,19 @@ app.layout = html.Div([
                 message='You selected Reject... Are you sure you want to continue?'
             ),
             html.Br(),
-            # The reviewer comment section
-            html.Label(['Enter comments here:'],
-                       style={'font-size': label_fontsize}),
-            html.Div(
-                dcc.Textarea(id='reviewer_comments',
-                             style={
-                                'width': sidebar_width,
-                                'height': comment_box_height,
-                                'font-size': label_fontsize
-                             })
-            ),
-            html.Br(),
             html.Button('\u2192',
                         id='next_annotation',
                         style={'height': button_height,
                                'width': button_width,
                                'font-size': 'large'}),
-        ], style={'display': 'inline-block', 'vertical-align': '50px',
-                  'padding-right': '50px'}),
+        ], style={'display': 'inline-block', 'vertical-align': 'top',
+                  'padding-top': '3%'}),
         # The plot itself
         html.Div([
             dcc.Graph(
                 id='the_graph',
-                config=plot_config
+                config=plot_config,
+                style={'height': '70vh', 'width': '80vw'}
             ),
         ], style={'display': 'inline-block'})
     ], type='default'),
@@ -321,8 +323,8 @@ def get_layout(fig_height, fig_width, margin_left, margin_top, margin_right,
 
     """
     return {
-        'height': fig_height,
-        'width': fig_width,
+        # 'height': fig_height,
+        # 'width': fig_width,
         'margin': {'l': margin_left,
                    't': margin_top,
                    'r': margin_right,

--- a/waveform-django/waveforms/templates/waveforms/adjudicator_console.html
+++ b/waveform-django/waveforms/templates/waveforms/adjudicator_console.html
@@ -4,8 +4,8 @@
 {% block content %}
 <style>
 .embed-responsive {
-    width: 1200px;
-    height: 820px;
+    width: 100%;
+    height: 90%;
 }
 .ui-resizable-e {
   width: 50%;
@@ -34,13 +34,13 @@ function displayCaliper() {
   if (caliper_wrapper.style.display == "none") {
     caliper_wrapper.style.display = "inline-block";
     caliper_wrapper.style.position = "absolute";
-    caliper_wrapper.style.left = "90%";
-    caliper_wrapper.style.top = "45%";
-    caliper_wrapper.style.padding = "25px";
-    caliper_resize.style.height = "100px";
-    caliper_resize.style.width = "80px";
-    caliper.style.height = "100px";
-    caliper.style.width = "80px";
+    caliper_wrapper.style.left = "92vw";
+    caliper_wrapper.style.top = "45vh";
+    caliper_wrapper.style.padding = "2hw";
+    caliper_resize.style.height = "11.11vh";
+    caliper_resize.style.width = "5.56vw";
+    caliper.style.height = "11.11vh";
+    caliper.style.width = "5.56vw";
   } else {
     caliper_wrapper.style.display = "none";
   }

--- a/waveform-django/waveforms/templates/waveforms/home.html
+++ b/waveform-django/waveforms/templates/waveforms/home.html
@@ -4,8 +4,8 @@
 {% block content %}
 <style>
 .embed-responsive {
-  width: 1200px;
-  height: 715px;
+  width: 100%;
+  height: 90%;
 }
 .ui-resizable-e {
   width: 50%;
@@ -33,13 +33,13 @@ function displayCaliper() {
   if (caliper_wrapper.style.display == "none") {
     caliper_wrapper.style.display = "inline-block";
     caliper_wrapper.style.position = "absolute";
-    caliper_wrapper.style.left = "89%";
-    caliper_wrapper.style.top = "20%";
-    caliper_wrapper.style.padding = "25px";
-    caliper_resize.style.height = "100px";
-    caliper_resize.style.width = "80px";
-    caliper.style.height = "100px";
-    caliper.style.width = "80px";
+    caliper_wrapper.style.left = "92vw";
+    caliper_wrapper.style.top = "25vh";
+    caliper_wrapper.style.padding = "2hw";
+    caliper_resize.style.height = "11.11vh";
+    caliper_resize.style.width = "5.56vw";
+    caliper.style.height = "11.11vh";
+    caliper.style.width = "5.56vw";
   } else {
     caliper_wrapper.style.display = "none";
   }


### PR DESCRIPTION
This change switches the CSS from absolute to relative values to work better across multiple platforms and also allows the annotator to be responsive (yes it works but it's kinda ugly right now). I also filled up more of the screen so there's less whitespace now which enables better viewing of the waveforms.

This introduces a small issue of no longer being able to adjust the figure height/width from the settings but I don't think that will be a real issue ... will fix it sometime later.