### PR TITLE
Fixes template pagination error

### DIFF
--- a/waveform-django/waveforms/templates/waveforms/adjudications.html
+++ b/waveform-django/waveforms/templates/waveforms/adjudications.html
@@ -111,8 +111,14 @@
       {% if complete_page.has_next %}
         <a href="{% url 'render_adjudications' %}?complete_page={{ complete_page.next_page_number }}#complete_adjudications">Next Page</a>&emsp;
       {% endif %}
-      {% if request.GET.complete_page == 'all' %}
-        <a href="{% url 'render_adjudications' %}?complete_page=1#complete_adjudications">Show pages</a>
+      {% if request.GET %}
+        {% if request.GET.complete_page == 'all' %}
+          <a href="{% url 'render_adjudications' %}?complete_page=1#complete_adjudications">Show pages</a>
+        {% else %}
+          {% if n_complete > 5 %}
+            <a href="{% url 'render_adjudications' %}?complete_page=all#complete_adjudications">Show all</a>
+          {% endif %}
+        {% endif %}
       {% else %}
         {% if n_complete > 5 %}
           <a href="{% url 'render_adjudications' %}?complete_page=all#complete_adjudications">Show all</a>
@@ -173,8 +179,14 @@
       {% if incomplete_page.has_next %}
         <a href="{% url 'render_adjudications' %}?incomplete_page={{ incomplete_page.next_page_number }}#incomplete_adjudications">Next Page</a>&emsp;
       {% endif %}
-      {% if request.GET.incomplete_page == 'all' %}
-        <a href="{% url 'render_adjudications' %}?incomplete_page=1#incomplete_adjudications">Show pages</a>
+      {% if request.GET %}
+        {% if request.GET.incomplete_page == 'all' %}
+          <a href="{% url 'render_adjudications' %}?incomplete_page=1#incomplete_adjudications">Show pages</a>
+        {% else %}
+          {% if n_incomplete > 5 %}
+            <a href="{% url 'render_adjudications' %}?incomplete_page=all#incomplete_adjudications">Show all</a>
+          {% endif %}
+        {% endif %}
       {% else %}
         {% if n_incomplete > 5 %}
           <a href="{% url 'render_adjudications' %}?incomplete_page=all#incomplete_adjudications">Show all</a>

--- a/waveform-django/waveforms/templates/waveforms/annotations.html
+++ b/waveform-django/waveforms/templates/waveforms/annotations.html
@@ -33,7 +33,7 @@
 
 <div class="container">
   <h1>All {%if user.practice_status != "ED"%} Practice {% endif %} Annotations</h1>
-  
+
   <div>
     <span style="font-size: 20px; float: left;">Total Complete</span>
     <span style="font-size: 20px; float: right;">{{ all_anns_frac }}</span>
@@ -195,15 +195,23 @@
   {% if complete_page %}
     <div class="page-links">
       {% if complete_page.has_previous %}
-        <a href="{% url 'render_annotations' %}?complete_page={{ complete_page.previous_page_number}}#complete_annotations">Previous Page</a>&emsp;
+        <a href="{% url 'render_annotations' %}?complete_page={{ complete_page.previous_page_number }}#complete_annotations">Previous Page</a>&emsp;
       {% endif %}
       {% if complete_page.has_next %}
-        <a href="{% url 'render_annotations' %}?complete_page={{ complete_page.next_page_number}}#complete_annotations">Next Page</a>&emsp;
+        <a href="{% url 'render_annotations' %}?complete_page={{ complete_page.next_page_number }}#complete_annotations">Next Page</a>&emsp;
       {% endif %}
-      {% if request.GET.complete_page == 'all' %}
-        <a href="{% url 'render_annotations' %}?complete_page=1#complete_annotations">Show pages</a>
+      {% if request.GET %}
+        {% if request.GET.complete_page == 'all' %}
+          <a href="{% url 'render_annotations' %}?complete_page=1#complete_annotations">Show pages</a>
+        {% else %}
+          {% if n_complete > 5 %}
+            <a href="{% url 'render_annotations' %}?incomplete_page=all#complete_annotations">Show all</a>
+          {% endif %}
+        {% endif %}
       {% else %}
-        <a href="{% url 'render_annotations' %}?complete_page=all#complete_annotations">Show all</a>
+        {% if n_complete > 5 %}
+          <a href="{% url 'render_annotations' %}?incomplete_page=all#complete_annotations">Show all</a>
+        {% endif %}
       {% endif %}
     </div>
   {% endif %}
@@ -248,18 +256,26 @@
   <div id="incomplete_annotations">
     <h2>Incomplete Annotations</h2>
   </div>
-  {% if incomplete_page%}
+  {% if incomplete_page %}
     <div class="page-links">
       {% if incomplete_page.has_previous %}
-        <a href="{% url 'render_annotations' %}?incomplete_page={{ incomplete_page.previous_page_number}}#incomplete_annotations">Previous Page</a>&emsp;
+        <a href="{% url 'render_annotations' %}?incomplete_page={{ incomplete_page.previous_page_number }}#incomplete_annotations">Previous Page</a>&emsp;
       {% endif %}
       {% if incomplete_page.has_next %}
-        <a href="{% url 'render_annotations' %}?incomplete_page={{ incomplete_page.next_page_number}}#incomplete_annotations">Next Page</a>&emsp;
+        <a href="{% url 'render_annotations' %}?incomplete_page={{ incomplete_page.next_page_number }}#incomplete_annotations">Next Page</a>&emsp;
       {% endif %}
-      {% if request.GET.incomplete_page == 'all' %}
-        <a href="{% url 'render_annotations' %}?incomplete_page=1#incomplete_annotations">Show pages</a>
+      {% if request.GET %}
+        {% if request.GET.incomplete_page == 'all' %}
+          <a href="{% url 'render_annotations' %}?incomplete_page=1#incomplete_annotations">Show pages</a>
+        {% else %}
+          {% if n_incomplete > 5 %}
+            <a href="{% url 'render_annotations' %}?incomplete_page=all#incomplete_annotations">Show all</a>
+          {% endif %}
+        {% endif %}
       {% else %}
-        <a href="{% url 'render_annotations' %}?incomplete_page=all#incomplete_annotations">Show all</a>
+        {% if n_incomplete > 5 %}
+          <a href="{% url 'render_annotations' %}?incomplete_page=all#incomplete_annotations">Show all</a>
+        {% endif %}
       {% endif %}
     </div>
   {% endif %}

--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -785,17 +785,19 @@ def render_annotations(request):
     saved_page = pag_saved.get_page(saved_page_num)
     saved_anns = dict(saved_page)
 
+    n_complete = len(completed_anns.items())
     complete_page_num = request.GET.get('complete_page')
     if complete_page_num == 'all':
-        pag_complete = Paginator(tuple(completed_anns.items()), len(completed_anns.items()))
+        pag_complete = Paginator(tuple(completed_anns.items()), n_complete)
     else:
         pag_complete = Paginator(tuple(completed_anns.items()), 5)
     complete_page = pag_complete.get_page(complete_page_num)
     completed_anns = dict(complete_page)
 
+    n_incomplete = len(incompleted_anns.items())
     incomplete_page_num = request.GET.get('incomplete_page')
     if incomplete_page_num == 'all':
-        pag_incomplete = Paginator(tuple(incompleted_anns.items()), len(incompleted_anns.items()))
+        pag_incomplete = Paginator(tuple(incompleted_anns.items()), n_incomplete)
     else:
         pag_incomplete = Paginator(tuple(incompleted_anns.items()), 5)
     incomplete_page = pag_incomplete.get_page(incomplete_page_num)
@@ -883,7 +885,8 @@ def render_annotations(request):
     return render(request, 'waveforms/annotations.html',
                   {'user': user, 'all_anns_frac': all_anns_frac,
                    'categories': categories, 'completed_anns': completed_anns,
-                   'complete_page': complete_page, 'search': search,
+                   'complete_page': complete_page, 'n_complete': n_complete,
+                   'n_incomplete': n_incomplete, 'search': search,
                    'saved_anns': saved_anns, 'saved_page': saved_page,
                    'incompleted_anns': incompleted_anns,
                    'incomplete_page': incomplete_page,


### PR DESCRIPTION
This change fixes an `AttributeError` that was showing up (and flooding) the production logs but weren't caught locally for some reason ... anyway, the cause of the error was that `request.GET` was empty at initial load so `request.GET.complete_page` and `request.GET.incomplete_page` would return an `AttributeError` which would only go away after one of those request links (i.e., next page, previous page, show all, show pages) were clicked. 