### PR TITLE
Fixes uneven assignments error

### DIFF
--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -75,7 +75,7 @@ def update_assignments(csv_data, project_folder):
                 else:
                     row.extend(set(user))
                 csvwriter.writerows([row])
-    
+
 
 def get_all_assignments(project_folder):
     """
@@ -843,7 +843,7 @@ def render_annotations(request):
             # First assign events that already have one user assigned
             for project,assignments in assigned_events.items():
                 for event,assignees in assignments.items():
-                    if len(assignees) == 1:
+                    if (len(assignees) == 1) and (user.username not in assignees):
                         assignees.append(user.username)
                         assigned_events[project][event] = assignees
                         num_events -= 1


### PR DESCRIPTION
This change fixes an error that occurs when there is an uneven amount of completed annotations by a single user. The error occurs when the number of events annotated by **ONLY** the user (which haven't been annotated by anyone else) is greater than the number of new events requested. This is because of #116 which adds the `set()` functionality which swallows these double assignments... which is good so this accounts for another edge case.