### PR TITLE
Paginated Admin Console

### DIFF
--- a/waveform-django/waveforms/templates/waveforms/admin_console.html
+++ b/waveform-django/waveforms/templates/waveforms/admin_console.html
@@ -159,9 +159,19 @@
     <br />
   </div>
   {% for project,k in conflict_anns.items %}
-    <h2>Project: {{ project }}</h2>
-    <h3><u>Conflicting Annotations</u></h3>
-    {% for rec,info in k.items %}
+    <h2 id="{{ project }}_conflicts">Project: {{ project }}</h2>
+    <h3><i>Conflicting Annotations</i></h3>
+
+    <div class="page-links">
+      {% if k.has_previous %}
+        <a href="{% url 'admin_console' %}?{{project}}_conflicts={{ k.previous_page_number }}#{{project}}_conflicts">Previous Page</a>&emsp;
+      {% endif %}
+      {% if k.has_next %}
+        <a href="{% url 'admin_console' %}?{{project}}_conflicts={{ k.next_page_number }}#{{project}}_conflicts">Next Page</a>&emsp;
+      {% endif %}
+    </div>
+
+    {% for rec,info in k %}
       {% if info|length > 0 %}
         <h4 style="float: left;">Record: {{ rec }}</h4><br /><br />
         {% for evt,nfo in info.items %}
@@ -187,12 +197,23 @@
         {% endfor %}
         <br />
       {% endif %}
+      <hr>
     {% endfor %}
   {% endfor %}
   {% for project,k in unanimous_anns.items %}
-    <h2>Project: {{ project }}</h2>
-    <h3><u>Unanimous Annotations</u></h3>
-    {% for rec,info in k.items %}
+    <h2 id="{{ project }}_unanimous">Project: {{ project }}</h2>
+    <h3><i>Unanimous Annotations</i></h3>
+
+    <div class="page-links">
+      {% if k.has_previous %}
+        <a href="{% url 'admin_console' %}?{{project}}_unanimous={{ k.previous_page_number }}#{{project}}_unanimous">Previous Page</a>&emsp;
+      {% endif %}
+      {% if k.has_next %}
+        <a href="{% url 'admin_console' %}?{{project}}_unanimous={{ k.next_page_number }}#{{project}}_unanimous">Next Page</a>&emsp;
+      {% endif %}
+    </div>
+
+    {% for rec,info in k %}
       {% if info|length > 0 %}
         <h4 style="float: left;">Record: {{ rec }}</h4><br /><br />
         {% for evt,nfo in info.items %}
@@ -218,12 +239,24 @@
         {% endfor %}
         <br />
       {% endif %}
+      <hr>
     {% endfor %}
   {% endfor %}
   {% for project,k in all_anns.items %}
-    <h2>Project: {{ project }}</h2>
-    <h3><u>Unfinished Annotations</u></h3>
-    {% for rec,info in k.items %}
+    <h2 id="{{ project }}_unfinished">Project: {{ project }}</h2>
+    <h3><i>Unfinished Annotations</i></h3>
+
+    <div class="page-links">
+      {% if k.has_previous %}
+        <a href="{% url 'admin_console' %}?{{project}}_unfinished={{ k.previous_page_number }}#{{project}}_unfinished">Previous Page</a>&emsp;
+      {% endif %}
+      {% if k.has_next %}
+        <a href="{% url 'admin_console' %}?{{project}}_unfinished={{ k.next_page_number }}#{{project}}_unfinished">Next Page</a>&emsp;
+      {% endif %}
+    </div>
+
+
+    {% for rec,info in k %}
       {% if info|length > 0 %}
         <h4 style="float: left;">Record: {{ rec }}</h4><br /><br />
         {% for evt,nfo in info.items %}
@@ -249,6 +282,7 @@
         {% endfor %}
         <br />
       {% endif %}
+      <hr>
     {% endfor %}
   {% endfor %}
 </div>

--- a/waveform-django/waveforms/templates/waveforms/annotations.html
+++ b/waveform-django/waveforms/templates/waveforms/annotations.html
@@ -205,12 +205,12 @@
           <a href="{% url 'render_annotations' %}?complete_page=1#complete_annotations">Show pages</a>
         {% else %}
           {% if n_complete > 5 %}
-            <a href="{% url 'render_annotations' %}?incomplete_page=all#complete_annotations">Show all</a>
+            <a href="{% url 'render_annotations' %}?complete_page=all#complete_annotations">Show all</a>
           {% endif %}
         {% endif %}
       {% else %}
         {% if n_complete > 5 %}
-          <a href="{% url 'render_annotations' %}?incomplete_page=all#complete_annotations">Show all</a>
+          <a href="{% url 'render_annotations' %}?complete_page=all#complete_annotations">Show all</a>
         {% endif %}
       {% endif %}
     </div>

--- a/waveform-django/waveforms/views.py
+++ b/waveform-django/waveforms/views.py
@@ -359,15 +359,12 @@ def admin_console(request):
         records = [a[0] for a in all_annotations]
         events = [a[1] for a in all_annotations]
 
-        conflict_anns[project] = {}
-        unanimous_anns[project] = {}
-        all_anns[project] = {}
+        conflict_anns[project] = defaultdict(dict)
+        unanimous_anns[project] = defaultdict(dict)
+        all_anns[project] = defaultdict(dict)
 
         # Get the events
         for rec in all_records[project]:
-            conflict_anns[project][rec] = {}
-            unanimous_anns[project][rec] = {}
-            all_anns[project][rec] = {}
             records_path = os.path.join(PROJECT_PATH, project, rec,
                                         base.RECORDS_FILE)
             with open(records_path, 'r') as f:
@@ -395,6 +392,7 @@ def admin_console(request):
                                                         ann[3], ann[4]])
                 else:
                     temp_all_anns.append(['-', '-', '-', '-', '-'])
+                
                 # Get the completion stats for each record
                 if temp_conflict_anns != []:
                     conflict_anns[project][rec][evt] = temp_conflict_anns
@@ -402,6 +400,25 @@ def admin_console(request):
                     unanimous_anns[project][rec][evt] = temp_unanimous_anns
                 if temp_all_anns != []:
                     all_anns[project][rec][evt] = temp_all_anns
+        
+        conf_page_num = request.GET.get(f"{project}_conflicts")
+        unan_page_num = request.GET.get(f"{project}_unanimous")
+        unfi_page_num = request.GET.get(f"{project}_unfinished")
+
+        page_conflict = Paginator(tuple(conflict_anns[project].items()), 3).get_page(conf_page_num)
+        page_unanimous = Paginator(tuple(unanimous_anns[project].items()), 3).get_page(unan_page_num)
+        page_unfinished = Paginator(tuple(all_anns[project].items()), 3).get_page(unfi_page_num)
+        
+        conflict_anns[project] = page_conflict
+        unanimous_anns[project] = page_unanimous
+        all_anns[project] = page_unfinished
+
+        if not page_conflict:
+            del conflict_anns[project]
+        if not unanimous_anns[project]:
+            del unanimous_anns[project]
+        if not all_anns[project]:
+            del all_anns[project]
 
     # Categories to display for the annotations
     categories = [

--- a/waveform-django/website/urls.py
+++ b/waveform-django/website/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
              template_name='registration/password_reset_complete.html'),
          name='password_reset_complete'),
     # Waveform annotator dashboard
+    path('', views.redirect_home),
     path('waveform-annotation/waveforms/', include('waveforms.urls')),
     # GraphQL API interface
     path('waveform-annotation/', include('export.urls')),

--- a/waveform-django/website/views.py
+++ b/waveform-django/website/views.py
@@ -10,6 +10,13 @@ from waveforms.models import InvitedEmails, User, UserSettings
 from website.settings import base
 
 
+def redirect_home(request):
+    """
+    Redirects users to home page
+    """
+    return redirect(login_page)
+
+
 def register_page(request):
     """
     Create a new account upon request.


### PR DESCRIPTION
The display of the admin console now shows a maximum of three records per category, with the option to scroll through pages. This should drastically improve the load times of the admin console.